### PR TITLE
Null field result written as object with default property values, not null

### DIFF
--- a/ch360/results/extraction.go
+++ b/ch360/results/extraction.go
@@ -4,7 +4,7 @@ type FieldResult struct {
 	FieldName    string `json:"field_name"`
 	Rejected     bool   `json:"rejected"`
 	RejectReason string `json:"reject_reason"`
-	Result       struct {
+	Result       *struct {
 		Text           string      `json:"text"`
 		Value          interface{} `json:"value"`
 		Rejected       bool        `json:"rejected"`


### PR DESCRIPTION
This fixes issue 85, where if the API returned a null result e.g.
```
"reject_reason": "Empty",
"result": null,
```
it was incorrectly deserialised to an empty struct (rather than nil) and when written out the results would include the struct with default property values.

---
Connects to #85.