### PR TITLE
Rename properties in surf extraction json output to match new API response

### DIFF
--- a/ch360/results/extraction.go
+++ b/ch360/results/extraction.go
@@ -20,7 +20,7 @@ type FieldResult struct {
 			PageNumber int     `json:"page_number"`
 		} `json:"areas"`
 	} `json:"result"`
-	AlternativeResults interface{} `json:"alternative_results"`
+	AlternativeResults interface{} `json:"alternatives"`
 	TabularResults     interface{} `json:"tabular_results"`
 }
 
@@ -35,5 +35,5 @@ type PageSizes struct {
 
 type ExtractionResult struct {
 	FieldResults []FieldResult `json:"field_results"`
-	PageSizes    PageSizes     `json:"page_sizes"`
+	PageSizes    PageSizes     `json:"document"`
 }

--- a/ch360/results/extraction.go
+++ b/ch360/results/extraction.go
@@ -24,7 +24,7 @@ type FieldResult struct {
 	TabularResults     interface{} `json:"tabular_results"`
 }
 
-type PageSizes struct {
+type Document struct {
 	PageCount int `json:"page_count"`
 	Pages     []struct {
 		PageNumber int     `json:"page_number"`
@@ -35,5 +35,5 @@ type PageSizes struct {
 
 type ExtractionResult struct {
 	FieldResults []FieldResult `json:"field_results"`
-	PageSizes    PageSizes     `json:"document"`
+	Document     Document      `json:"document"`
 }


### PR DESCRIPTION
🚧 No not merge this until all changes are ready

This change updates surf's extraction json output to rename the following properties:
 - `page_sizes` to `document`
 - `alternative_results` to `alternatives`

---
Connects to CloudHub360/platform#848