### PR TITLE
Adjust relative confidence score for acceptance test

### DIFF
--- a/test/surf-classifier.Tests.ps1
+++ b/test/surf-classifier.Tests.ps1
@@ -161,7 +161,7 @@ document1.pdf                        Notice of Lien                   true
         $results.filename | Should -BeLike "*document2.pdf"
         $results.classification_results.document_type | Should -Be "Notice of Lien"
         $results.classification_results.is_confident | Should -Be True
-        $results.classification_results.relative_confidence | Should -Be 1.17683673
+        $results.classification_results.relative_confidence | Should -Be 1.1768367290496826
 
         Remove-Item -Path $outputFile
     }


### PR DESCRIPTION
Due to an update to the classification service (probably) the relative confidence score of this one class is more precise than previously. This updates the test to use the more precise figure.

A more correct (and long-term) fix is to find a way to compare relative confidence scores within a degree of accuracy, so that the test continues to pass in this situation.