### PR TITLE
Make DetailedErrorResponse.Error return detail if present

### DIFF
--- a/ch360/responsecheckingdoer_test.go
+++ b/ch360/responsecheckingdoer_test.go
@@ -3,6 +3,7 @@ package ch360_test
 import (
 	"github.com/CloudHub360/ch360.go/ch360"
 	"github.com/CloudHub360/ch360.go/net/mocks"
+	"github.com/CloudHub360/ch360.go/response"
 	mockresponse "github.com/CloudHub360/ch360.go/response/mocks"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -81,4 +82,35 @@ func (suite *ResponseCheckingDoerSuite) Test_ResponseCheckingDoer_Returns_Err_Fr
 
 	// Assert
 	assert.Equal(suite.T(), expectedErr, receivedErr)
+}
+
+func Test_DetailedErrorResponse_Error_Returns_Detail_Message(t *testing.T) {
+	fixtures := []struct {
+		title       string
+		detail      string
+		expectedErr string
+	}{
+		{
+			title:       "",
+			detail:      "detail message",
+			expectedErr: "detail message",
+		}, {
+			title:       "title",
+			detail:      "detail message",
+			expectedErr: "detail message",
+		}, {
+			title:       "title",
+			expectedErr: "title",
+		},
+	}
+
+	for _, fixture := range fixtures {
+
+		sut := response.DetailedErrorResponse{
+			Title:  fixture.title,
+			Detail: fixture.detail,
+		}
+
+		assert.Equal(t, fixture.expectedErr, sut.Error())
+	}
 }

--- a/cmd/surf/commands/createextractor.go
+++ b/cmd/surf/commands/createextractor.go
@@ -113,7 +113,7 @@ func buildDetailedErrorMessage(errorResponse response.DetailedErrorResponse) err
 
 	sb := strings.Builder{}
 	sb.WriteString("Extractor creation failed with the following error: ")
-	sb.WriteString(fmt.Sprintf("%s\n", errorResponse.Title))
+	sb.WriteString(fmt.Sprintf("%s\n", errorResponse.Error()))
 
 	// group error info by module
 	errorsByModule := map[string][]detailedError{}

--- a/response/responsechecker.go
+++ b/response/responsechecker.go
@@ -71,8 +71,12 @@ type DetailedErrorResponse struct {
 	Title    string                   `json:"title"`
 	Status   int                      `json:"status"`
 	Instance string                   `json:"instance"`
+	Detail   string                   `json:"detail"`
 }
 
 func (e *DetailedErrorResponse) Error() string {
+	if len(e.Detail) > 0 {
+		return e.Detail
+	}
 	return e.Title
 }


### PR DESCRIPTION
The rfc7807 problem responses can include detailed information about the
error. This change ensures it is used in preference to the 'title', in
the `Error` method of the DetailedErrorResponse type.

The `create extractor` command is also updated to use the `Error` method
in place of `Title`, directly, so attempting to create a duplicate
extractor will now result in an error message like this:

`Extractor creation failed with the following error: There is already an
extractor called 'test'. Please use another name for the new extractor.`

Fixes #119 