### PR TITLE
Add option to log http requests

### DIFF
--- a/ch360/apiclient.go
+++ b/ch360/apiclient.go
@@ -4,6 +4,7 @@ import (
 	"github.com/CloudHub360/ch360.go/auth"
 	"github.com/CloudHub360/ch360.go/net"
 	"github.com/CloudHub360/ch360.go/response"
+	"os"
 )
 
 const ApiAddress = "https://api.waives.io"
@@ -23,14 +24,19 @@ func NewTokenRetriever(httpClient net.HttpDoer, apiUrl string) auth.TokenRetriev
 			&response.ErrorChecker{}))
 }
 
-func NewApiClient(httpClient net.HttpDoer, apiUrl string, clientId string, clientSecret string) *ApiClient {
+func NewApiClient(httpClient net.HttpDoer, apiUrl string, clientId string, clientSecret string, log bool) *ApiClient {
 
-	ctxhttpClient := net.NewContextAwareHttpClient(httpClient)
+	var myHttpClient net.HttpDoer
+	myHttpClient = net.NewContextAwareHttpClient(httpClient)
 
-	tokenRetriever := NewTokenRetriever(ctxhttpClient, apiUrl)
+	if log {
+		myHttpClient = NewLoggingDoer(myHttpClient, os.Stderr)
+	}
+
+	tokenRetriever := NewTokenRetriever(myHttpClient, apiUrl)
 
 	authorisingDoer := AuthorisingDoer{
-		wrappedSender:  ctxhttpClient,
+		wrappedSender:  myHttpClient,
 		tokenRetriever: tokenRetriever,
 		clientId:       clientId,
 		clientSecret:   clientSecret,

--- a/ch360/apiclient.go
+++ b/ch360/apiclient.go
@@ -4,7 +4,7 @@ import (
 	"github.com/CloudHub360/ch360.go/auth"
 	"github.com/CloudHub360/ch360.go/net"
 	"github.com/CloudHub360/ch360.go/response"
-	"os"
+	"io"
 )
 
 const ApiAddress = "https://api.waives.io"
@@ -24,13 +24,13 @@ func NewTokenRetriever(httpClient net.HttpDoer, apiUrl string) auth.TokenRetriev
 			&response.ErrorChecker{}))
 }
 
-func NewApiClient(httpClient net.HttpDoer, apiUrl string, clientId string, clientSecret string, log bool) *ApiClient {
+func NewApiClient(httpClient net.HttpDoer, apiUrl string, clientId string, clientSecret string, httpLogSink io.Writer) *ApiClient {
 
 	var myHttpClient net.HttpDoer
 	myHttpClient = net.NewContextAwareHttpClient(httpClient)
 
-	if log {
-		myHttpClient = NewLoggingDoer(myHttpClient, os.Stderr)
+	if httpLogSink != nil {
+		myHttpClient = NewLoggingDoer(myHttpClient, httpLogSink)
 	}
 
 	tokenRetriever := NewTokenRetriever(myHttpClient, apiUrl)

--- a/ch360/logginghttpdoer.go
+++ b/ch360/logginghttpdoer.go
@@ -1,0 +1,78 @@
+package ch360
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/CloudHub360/ch360.go/net"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+)
+
+type LoggingDoer struct {
+	wrappedSender net.HttpDoer
+	out           io.Writer
+}
+
+func NewLoggingDoer(httpDoer net.HttpDoer, out io.Writer) *LoggingDoer {
+	return &LoggingDoer{
+		wrappedSender: httpDoer,
+		out:           out,
+	}
+}
+
+func (d *LoggingDoer) Do(request *http.Request) (*http.Response, error) {
+	requestBytes, err := httputil.DumpRequestOut(request, false)
+
+	if err != nil {
+		return nil, err
+	}
+	_, err = d.out.Write(requestBytes)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if request.Body != nil {
+		body, err := request.GetBody()
+
+		if err != nil {
+			return nil, err
+		}
+
+		bodyBuffer := bytes.Buffer{}
+		_, _ = bodyBuffer.ReadFrom(body)
+
+		if json.Valid(bodyBuffer.Bytes()) {
+			formattedJson := bytes.Buffer{}
+			_ = json.Indent(&formattedJson, bodyBuffer.Bytes(), "", "  ")
+			formattedJson.WriteTo(d.out)
+			d.out.Write([]byte("\n"))
+		} else {
+			d.out.Write([]byte("<binary request body>\n\n"))
+		}
+	}
+
+	response, capturedErr := d.wrappedSender.Do(request)
+
+	responseBodyBuffer := bytes.Buffer{}
+	responseBodyBuffer.ReadFrom(response.Body)
+	bodyReader := bytes.NewReader(responseBodyBuffer.Bytes())
+	response.Body = ioutil.NopCloser(bodyReader)
+
+	responseBytes, err := httputil.DumpResponse(response, false)
+
+	d.out.Write(responseBytes)
+
+	if json.Valid(responseBodyBuffer.Bytes()) {
+		formattedJson := bytes.Buffer{}
+		json.Indent(&formattedJson, responseBodyBuffer.Bytes(), "", "  ")
+		formattedJson.WriteTo(d.out)
+	} else {
+		d.out.Write([]byte("<binary response body>\n\n"))
+	}
+
+	d.out.Write([]byte("\n"))
+	return response, capturedErr
+}

--- a/ch360/logginghttpdoer_test.go
+++ b/ch360/logginghttpdoer_test.go
@@ -1,0 +1,1 @@
+package ch360

--- a/ch360/logginghttpdoer_test.go
+++ b/ch360/logginghttpdoer_test.go
@@ -1,1 +1,79 @@
 package ch360
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/CloudHub360/ch360.go/net/mocks"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+func Test_LoggingHttpDoer_Logs_To_Provided_Sink(t *testing.T) {
+	fixtures := []struct {
+		requestBody    []byte
+		responseBody   []byte
+		isRequestJson  bool
+		isResponseJson bool
+	}{
+		{
+			requestBody:    nil,
+			isRequestJson:  false,
+			responseBody:   []byte("non-json-body"),
+			isResponseJson: false,
+		}, {
+			requestBody:    []byte("some binary bytes go here"),
+			isRequestJson:  false,
+			responseBody:   []byte(`{"jsonmessage":"all good"}`),
+			isResponseJson: true, // json response body should be logged
+		}, {
+			requestBody:    []byte(`{"jsonmessage":"json request body"}`),
+			isRequestJson:  true, // json request body should be logged
+			responseBody:   []byte("non-json-body"),
+			isResponseJson: false,
+		},
+	}
+
+	for _, fixture := range fixtures {
+
+		// Arrange
+		httpDoer := mocks.HttpDoer{}
+		logSink := bytes.Buffer{}
+		sut := LoggingDoer{
+			wrappedSender: &httpDoer,
+			out:           &logSink,
+		}
+		request, _ := http.NewRequest("GET", "https://api.waives.io", bytes.NewBuffer(fixture.requestBody))
+		response := http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(fixture.responseBody)),
+		}
+		httpDoer.
+			On("Do", request).
+			Return(&response, nil)
+
+		// Act
+		_, _ = sut.Do(request)
+
+		// Assert
+		assert.Contains(t, logSink.String(), "GET / HTTP/1.1\r\nHost: api.waives.io")
+		if fixture.isRequestJson {
+			assert.Contains(t, logSink.String(), formatJson(string(fixture.requestBody)))
+		}
+		if fixture.isResponseJson {
+			assert.Contains(t, logSink.String(), formatJson(string(fixture.responseBody)))
+		}
+	}
+}
+
+func formatJson(input string) string {
+	dst := bytes.Buffer{}
+	err := json.Indent(&dst, []byte(input), "", "  ")
+
+	if err != nil {
+		panic(err)
+	}
+
+	return dst.String()
+}

--- a/cmd/surf/surf.go
+++ b/cmd/surf/surf.go
@@ -133,7 +133,6 @@ func initApiClient(params *config.RunParams) (*ch360.ApiClient, error) {
 		if httpLogSink, err = os.Create(params.LogHttp); err != nil {
 			return nil, errors.WithMessage(err, "Unable to open HTTP log file")
 		}
-
 	}
 
 	return ch360.NewApiClient(DefaultHttpClient, ch360.ApiAddress, clientId, clientSecret, httpLogSink), nil

--- a/cmd/surf/surf.go
+++ b/cmd/surf/surf.go
@@ -50,6 +50,7 @@ Options:
                                      redirecting stdout or in conjunction with -m or -o.
   -t, --from-template <template>   : The extractor modules template to use when creating an
                                      extractor from modules.
+  --verbose-http                   : Log HTTP requests and responses as they happen, to stderr.
 `
 
 	filenameExamples := `
@@ -125,7 +126,7 @@ func initApiClient(params *config.RunParams) (*ch360.ApiClient, error) {
 		return nil, err
 	}
 
-	return ch360.NewApiClient(DefaultHttpClient, ch360.ApiAddress, clientId, clientSecret), nil
+	return ch360.NewApiClient(DefaultHttpClient, ch360.ApiAddress, clientId, clientSecret, params.VerboseHttp), nil
 }
 
 var DefaultHttpClient = &http.Client{Timeout: time.Minute * 5}

--- a/config/runparams.go
+++ b/config/runparams.go
@@ -34,7 +34,7 @@ type RunParams struct {
 	ShowProgress bool   `docopt:"-p,--progress"`
 	ClientId     string `docopt:"-i,--client-id"`
 	ClientSecret string `docopt:"-s,--client-secret"`
-	VerboseHttp  bool   `docopt:"--verbose-http"`
+	LogHttp      string `docopt:"--log-http"`
 
 	ModulesTemplate string   `docopt:"-t,--from-template"`
 	ModuleIds       []string `docopt:"<module-ids>"`

--- a/config/runparams.go
+++ b/config/runparams.go
@@ -34,6 +34,7 @@ type RunParams struct {
 	ShowProgress bool   `docopt:"-p,--progress"`
 	ClientId     string `docopt:"-i,--client-id"`
 	ClientSecret string `docopt:"-s,--client-secret"`
+	VerboseHttp  bool   `docopt:"--verbose-http"`
 
 	ModulesTemplate string   `docopt:"-t,--from-template"`
 	ModuleIds       []string `docopt:"<module-ids>"`


### PR DESCRIPTION
This PR adds the `--log-http` param, which accepts a file as a value. Eg:

`surf extract  "/home/phil/ch360-sync/Demos/extraction-invoice/*.tiff"  test --log-http=http.log`

This creates a file called `http.log` with any json requests and responses formatted to be human-readable, and any non-json payloads redacted, eg:

```
[0001 -->] POST /oauth/token HTTP/1.1
Host: api.waives.io
User-Agent: Go-http-client/1.1
Content-Length: 151
Content-Type: application/x-www-form-urlencoded
Accept-Encoding: gzip

<binary request body>

[0001 <--] HTTP/2.0 200 OK
Content-Length: 831
Content-Type: application/json; charset=utf-8
Date: Tue, 09 Jul 2019 09:10:48 GMT
Server: Kestrel

{
  "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlFUTXhPRE14TlRFM05rUTJORGs0UkRRMVFURXdOelpCTVVFeE9VVkJNakk1T0VORk5VVTFOZyJ9.eyJpc3MiOiJodHRwczovL2Nsb3VkaHViMzYwLmV1LmF1dGgwLmNvbS8iLCJzdWIiOiJGV1JhSkhwaDl2ZVBocmozRm5JSER3NlI1cnpjY3dsZEBjbGllbnRzIiwiYXVkIjoiaHR0cHM6Ly9hcGkuY2xvdWRodWIzNjAuY29tIiwiaWF0IjoxNTYyNjYzNDQ5LCJleHAiOjE1NjI3NDk4NDksImF6cCI6IkZXUmFKSHBoOXZlUGhyajNGbklIRHc2UjVyemNjd2xkIiwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIn0.qM9L3gHcUm_RVreeU1at3iTiW4ZMCC3220lvy4xgQu6ptyLkJz4PBuH5QCmHUuLUzmIMK77-BPu0RpHI9YLfeVESHFwsTiNMxTqpPy5fmG1vUF1hRD88dWsAsFfgxAOHLKctAJt_zbvaLhINUGlFb0IHmZ6ja28tb7A_b7DUL5MzvcRi06CnnmfexfuGN6TMCfCA2EP6kCVK-DTNnSkdc59uD_cWJxqpHoYc_zhl8XPpKU7ZeCHsSRaUZnuFVC_aZgHBplsFJSRhzWQwrt4hPNiNMXaYHZRgYq12kX9TnQFM0gqSeid08xjb-ejKZXG1hB0RdqS4JO0jX6uEd6c9Cg",
  "token_type": "Bearer",
  "expires_in": 86400
}

[0002 -->] GET /documents HTTP/1.1
Host: api.waives.io
User-Agent: Go-http-client/1.1
Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlFUTXhPRE14TlRFM05rUTJORGs0UkRRMVFURXdOelpCTVVFeE9VVkJNakk1T0VORk5VVTFOZyJ9.eyJpc3MiOiJodHRwczovL2Nsb3VkaHViMzYwLmV1LmF1dGgwLmNvbS8iLCJzdWIiOiJGV1JhSkhwaDl2ZVBocmozRm5JSER3NlI1cnpjY3dsZEBjbGllbnRzIiwiYXVkIjoiaHR0cHM6Ly9hcGkuY2xvdWRodWIzNjAuY29tIiwiaWF0IjoxNTYyNjYzNDQ5LCJleHAiOjE1NjI3NDk4NDksImF6cCI6IkZXUmFKSHBoOXZlUGhyajNGbklIRHc2UjVyemNjd2xkIiwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIn0.qM9L3gHcUm_RVreeU1at3iTiW4ZMCC3220lvy4xgQu6ptyLkJz4PBuH5QCmHUuLUzmIMK77-BPu0RpHI9YLfeVESHFwsTiNMxTqpPy5fmG1vUF1hRD88dWsAsFfgxAOHLKctAJt_zbvaLhINUGlFb0IHmZ6ja28tb7A_b7DUL5MzvcRi06CnnmfexfuGN6TMCfCA2EP6kCVK-DTNnSkdc59uD_cWJxqpHoYc_zhl8XPpKU7ZeCHsSRaUZnuFVC_aZgHBplsFJSRhzWQwrt4hPNiNMXaYHZRgYq12kX9TnQFM0gqSeid08xjb-ejKZXG1hB0RdqS4JO0jX6uEd6c9Cg
Accept-Encoding: gzip


[0002 <--] HTTP/2.0 200 OK
Content-Length: 613
Content-Type: application/json; charset=utf-8
Date: Tue, 09 Jul 2019 09:10:48 GMT
Server: Kestrel

{
  "documents": [
    {
      "id": "g6X13zkhlU6fFSXV9Q3W1A",
<-- snip -->
```