### PR TITLE
Fix race condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# ch360.go
-The go api client and cmd line tool
+# Surf, the command line client for waives.io
+
+surf allows you to quickly get started using [waives.io](https://waives.io). It can:
+ * Perform OCR on documents and images, and generate searchable PDFs
+ * Extract data from documents
+ * Classify documents
+ * Create custom extractors from modules
+ * ...and more!
+
+This repo also includes the waives.io client library for go, and is intended as a 'best-practice' integration with the [waives.io API](https://docs.waives.io/reference).
+
+More documentation is available [here](https://docs.waives.io).

--- a/ch360/apiclient.go
+++ b/ch360/apiclient.go
@@ -24,10 +24,17 @@ func NewTokenRetriever(httpClient net.HttpDoer, apiUrl string) auth.TokenRetriev
 			&response.ErrorChecker{}))
 }
 
-func NewApiClient(httpClient net.HttpDoer, apiUrl string, clientId string, clientSecret string, httpLogSink io.Writer) *ApiClient {
+func NewApiClient(httpClient net.HttpDoer,
+	apiUrl string,
+	clientId string,
+	clientSecret string,
+	httpLogSink io.Writer) *ApiClient {
 
 	var myHttpClient net.HttpDoer
-	myHttpClient = net.NewContextAwareHttpClient(httpClient)
+
+	myHttpClient = net.NewUserAgentHttpClient(httpClient, "surf/"+Version)
+
+	myHttpClient = net.NewContextAwareHttpClient(myHttpClient)
 
 	if httpLogSink != nil {
 		myHttpClient = NewLoggingDoer(myHttpClient, httpLogSink)

--- a/ch360/requestfactory.go
+++ b/ch360/requestfactory.go
@@ -25,6 +25,8 @@ func newRequest(ctx context.Context, method string, url string, body io.Reader) 
 
 	request = request.WithContext(ctx)
 
+	request.Header.Add("User-Agent", "surf/"+Version)
+
 	return &requestBuilder{
 		request: request,
 	}

--- a/ch360/requestfactory.go
+++ b/ch360/requestfactory.go
@@ -25,8 +25,6 @@ func newRequest(ctx context.Context, method string, url string, body io.Reader) 
 
 	request = request.WithContext(ctx)
 
-	request.Header.Add("User-Agent", "surf/"+Version)
-
 	return &requestBuilder{
 		request: request,
 	}

--- a/cmd/surf/surf.go
+++ b/cmd/surf/surf.go
@@ -48,7 +48,7 @@ Options:
   -o, --output-file <file>         : Write all results to the specified file
   -m, --multiple-files             : Write results output to multiple files with the same
                                    : basename as the input
-  -p, --progress                   : Show progress when classifying files. Only visible when
+  -p, --progress                   : Show progress when processing files. Only visible when
                                      redirecting stdout or in conjunction with -m or -o.
   -t, --from-template <template>   : The extractor modules template to use when creating an
                                      extractor from modules.

--- a/net/userhttp.go
+++ b/net/userhttp.go
@@ -1,0 +1,27 @@
+package net
+
+import "net/http"
+
+var _ HttpDoer = (*UserAgentHttpClient)(nil)
+
+// UserAgentHttpClient is an HttpDoer decorator that sets the "User-Agent"
+// HTTP header on requests.
+type UserAgentHttpClient struct {
+	wrapper   HttpDoer
+	userAgent string
+}
+
+func (h *UserAgentHttpClient) Do(request *http.Request) (*http.Response, error) {
+	if request != nil {
+		request.Header.Add("User-Agent", h.userAgent)
+	}
+
+	return h.wrapper.Do(request)
+}
+
+func NewUserAgentHttpClient(wrapper HttpDoer, userAgent string) *UserAgentHttpClient {
+	return &UserAgentHttpClient{
+		wrapper:   wrapper,
+		userAgent: userAgent,
+	}
+}

--- a/net/userhttp_test.go
+++ b/net/userhttp_test.go
@@ -1,0 +1,41 @@
+package net
+
+import (
+	"errors"
+	"github.com/CloudHub360/ch360.go/net/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"net/http"
+	"testing"
+)
+
+func TestUserAgentHttpClient_Sets_Correct_Header(t *testing.T) {
+	// Arrange
+	wrapped := mocks.HttpDoer{}
+	wrapped.On("Do", mock.Anything).Return(nil, nil)
+	sut := NewUserAgentHttpClient(&wrapped, "test-agent")
+	request, _ := http.NewRequest("GET", "https://api.waives.io", nil)
+
+	// Act
+	_, _ = sut.Do(request)
+
+	// Assert
+	assert.Equal(t, "test-agent", request.Header.Get("User-Agent"))
+}
+
+func TestUserAgentHttpClient_Returns_Values_From_Wrapped_HttpDoer(t *testing.T) {
+	// Arrange
+	wrapped := mocks.HttpDoer{}
+	expectedResponse := &http.Response{}
+	expectedErr := errors.New("test error")
+	wrapped.On("Do", mock.Anything).Return(expectedResponse, expectedErr)
+	sut := NewUserAgentHttpClient(&wrapped, "test-agent")
+	request, _ := http.NewRequest("GET", "https://api.waives.io", nil)
+
+	// Act
+	actualResponse, actualErr := sut.Do(request)
+
+	// Assert
+	assert.Equal(t, expectedResponse, actualResponse)
+	assert.Equal(t, expectedErr, actualErr)
+}

--- a/output/progress/progresshandler.go
+++ b/output/progress/progresshandler.go
@@ -31,6 +31,9 @@ func NewProgressHandlerFor(params *config.RunParams, progressOut io.Writer) (*Pr
 func NewProgressHandler(resultsWriter resultsWriters.ResultsWriter, showProgress bool, progressOut io.Writer) *ProgressHandler {
 	progress := uiprogress.New()
 	progress.SetOut(progressOut)
+
+	progress.Start()
+
 	return &ProgressHandler{
 		resultsWriter: resultsWriter,
 		showProgress:  showProgress,
@@ -62,7 +65,6 @@ func (c *ProgressHandler) NotifyErr(filename string, err error) error {
 }
 
 func (c *ProgressHandler) initProgressBar(total int) {
-	c.progress.Start()
 	c.progressBar = c.progress.AddBar(total).PrependFunc(func(bar *uiprogress.Bar) string {
 		return fmt.Sprintf("Processing file [%d/%d]", bar.Current(), bar.Total)
 	})

--- a/output/progress/progresshandler_test.go
+++ b/output/progress/progresshandler_test.go
@@ -21,6 +21,12 @@ type ClassifyProgressHandlerSuite struct {
 	outBuffer        *bytes.Buffer
 }
 
+func (suite *ClassifyProgressHandlerSuite) TearDownTest() {
+	for _, sut := range suite.suts {
+		_ = sut.NotifyFinish()
+	}
+}
+
 func (suite *ClassifyProgressHandlerSuite) SetupTest() {
 	suite.mockResultWriter = &mocks.ResultsWriter{}
 	suite.outBuffer = new(bytes.Buffer)
@@ -54,38 +60,36 @@ func TestClassifyProgressHandlerSuiteRunner(t *testing.T) {
 	suite.Run(t, new(ClassifyProgressHandlerSuite))
 }
 
-// TODO fix race condition exposed by this test
-//func (suite *ClassifyProgressHandlerSuite) Test_ClassifyProgressHandler_Calls_Underlying_ResultWriter() {
-//	for _, sut := range suite.suts {
-//		// Arrange
-//		expectedFilename := generators.String("filename")
-//		expectedResult := AClassificationResult()
-//
-//		// Act
-//		sut.NotifyStart(1)
-//		sut.Notify(expectedFilename, expectedResult)
-//
-//		// Assert
-//		suite.mockResultWriter.AssertCalled(suite.T(), "WriteResult", expectedFilename, expectedResult)
-//	}
-//}
+func (suite *ClassifyProgressHandlerSuite) Test_ClassifyProgressHandler_Calls_Underlying_ResultWriter() {
+	for _, sut := range suite.suts {
+		// Arrange
+		expectedFilename := generators.String("filename")
+		expectedResult := AClassificationResult()
 
-// TODO fix race condition exposed by this test
-//func (suite *ClassifyProgressHandlerSuite) Test_ClassifyProgressHandler_Returns_Error_From_ResultWriter() {
-//	for _, sut := range suite.suts {
-//		// Arrange
-//		expectedErr := errors.New("simulated error")
-//		suite.setupMockResultWriter(true, false, false)
-//		suite.mockResultWriter.On("WriteResult", mock.Anything, mock.Anything).Return(expectedErr)
-//
-//		// Act
-//		sut.NotifyStart(rand.Int())
-//		receivedErr := sut.Notify(generators.String("filename"), AClassificationResult())
-//
-//		// Assert
-//		suite.Assert().Equal(expectedErr, receivedErr)
-//	}
-//}
+		// Act
+		sut.NotifyStart(1)
+		sut.Notify(expectedFilename, expectedResult)
+
+		// Assert
+		suite.mockResultWriter.AssertCalled(suite.T(), "WriteResult", expectedFilename, expectedResult)
+	}
+}
+
+func (suite *ClassifyProgressHandlerSuite) Test_ClassifyProgressHandler_Returns_Error_From_ResultWriter() {
+	for _, sut := range suite.suts {
+		// Arrange
+		expectedErr := errors.New("simulated error")
+		suite.setupMockResultWriter(true, false, true)
+		suite.mockResultWriter.On("WriteResult", mock.Anything, mock.Anything).Return(expectedErr)
+
+		// Act
+		sut.NotifyStart(rand.Int())
+		receivedErr := sut.Notify(generators.String("filename"), AClassificationResult())
+
+		// Assert
+		suite.Assert().Equal(expectedErr, receivedErr)
+	}
+}
 
 func (suite *ClassifyProgressHandlerSuite) Test_ClassifyProgressHandler_Returns_Error_If_Notify_Is_Called_Before_NotifyStart() {
 	for _, sut := range suite.suts {


### PR DESCRIPTION
This PR ensures the unit tests properly close / stop all progress handlers before creating and starting new ones (which previously caused the race condition detector to fire).

It also 
 * updates the README.md file
 * customises the http user-agent header 
 * fixes a nil-deref crash in the LoggingDoer.

Fixes #126 