### PR TITLE
Fail if document slots are used

### DIFF
--- a/ch360/docslots.go
+++ b/ch360/docslots.go
@@ -1,0 +1,27 @@
+package ch360
+
+import (
+	"context"
+	"errors"
+)
+
+var ErrDocSlotsFull = errors.New("all document slots are full")
+
+// GetFreeDocSlots is a helper function to retrieve the number of available document slots in
+// waives, and return an error if there are none.
+func GetFreeDocSlots(ctx context.Context, getter DocumentGetter, totalSlots int) (int,
+	error) {
+	documentList, err := getter.GetAll(ctx)
+
+	if err != nil {
+		return 0, err
+	}
+
+	slots := totalSlots - len(documentList)
+
+	if slots == 0 {
+		return slots, ErrDocSlotsFull
+	}
+
+	return slots, nil
+}

--- a/ch360/docslots.go
+++ b/ch360/docslots.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 )
 
+var TotalDocumentSlots = 30
+
 var ErrDocSlotsFull = errors.New("all document slots are full")
 
 // GetFreeDocSlots is a helper function to retrieve the number of available document slots in
@@ -19,7 +21,10 @@ func GetFreeDocSlots(ctx context.Context, getter DocumentGetter, totalSlots int)
 
 	slots := totalSlots - len(documentList)
 
-	if slots == 0 {
+	// since the total doc slots is currently hardcoded,
+	// it's possible (even likely) that the actual number
+	// of documents in waives can be be greater than TotalDocumentSlots.
+	if slots <= 0 {
 		return slots, ErrDocSlotsFull
 	}
 

--- a/ch360/docslots_test.go
+++ b/ch360/docslots_test.go
@@ -32,6 +32,12 @@ func Test_GetFreeDocSlots(t *testing.T) {
 			expectedErr:   ch360.ErrDocSlotsFull,
 			ctx:           context.Background(),
 		}, {
+			totalSlots:    2,
+			presentDocs:   aListOfDocuments("1", "2", "3"),
+			expectedSlots: -1,
+			expectedErr:   ch360.ErrDocSlotsFull,
+			ctx:           context.Background(),
+		}, {
 			totalSlots:    10,
 			presentDocs:   aListOfDocuments("1", "2", "3"),
 			expectedSlots: 7,

--- a/ch360/docslots_test.go
+++ b/ch360/docslots_test.go
@@ -1,0 +1,80 @@
+package ch360_test
+
+import (
+	"context"
+	"errors"
+	"github.com/CloudHub360/ch360.go/ch360"
+	"github.com/CloudHub360/ch360.go/ch360/mocks"
+	"github.com/CloudHub360/ch360.go/test/generators"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+func Test_GetFreeDocSlots(t *testing.T) {
+	fixtures := []struct {
+		totalSlots    int
+		presentDocs   ch360.DocumentList
+		expectedSlots int
+		expectedErr   error
+		ctx           context.Context
+	}{
+		{
+			totalSlots:    10,
+			presentDocs:   nil,
+			expectedSlots: 10,
+			expectedErr:   nil,
+			ctx:           context.Background(),
+		}, {
+			totalSlots:    3,
+			presentDocs:   aListOfDocuments("1", "2", "3"),
+			expectedSlots: 0,
+			expectedErr:   ch360.ErrDocSlotsFull,
+			ctx:           context.Background(),
+		}, {
+			totalSlots:    10,
+			presentDocs:   aListOfDocuments("1", "2", "3"),
+			expectedSlots: 7,
+			expectedErr:   nil,
+			ctx:           context.Background(),
+		},
+	}
+
+	docGetter := &mocks.DocumentGetter{}
+
+	for _, fixture := range fixtures {
+		docGetter.ExpectedCalls = nil
+		docGetter.On("GetAll", mock.Anything).Return(fixture.presentDocs, nil)
+
+		actualSlots, actualErr := ch360.GetFreeDocSlots(fixture.ctx, docGetter, fixture.totalSlots)
+
+		assert.Equal(t, fixture.expectedSlots, actualSlots)
+		assert.Equal(t, fixture.expectedErr, actualErr)
+	}
+}
+
+func Test_GetFreeDocSlots_Returns_Err_From_DocGetter(t *testing.T) {
+	expectedErr := errors.New("simulated error")
+	docGetter := &mocks.DocumentGetter{}
+	docGetter.ExpectedCalls = nil
+	docGetter.On("GetAll", mock.Anything).Return(nil, expectedErr)
+
+	_, actualErr := ch360.GetFreeDocSlots(context.Background(), docGetter, 10)
+
+	assert.Equal(t, expectedErr, actualErr)
+}
+
+func aListOfDocuments(ids ...string) ch360.DocumentList {
+	expected := make(ch360.DocumentList, len(ids))
+
+	for index, id := range ids {
+		expected[index] = ch360.Document{
+			Id:       id,
+			Size:     generators.Int(),
+			Sha256:   generators.String("sha"),
+			FileType: generators.String("fileType"),
+		}
+	}
+
+	return expected
+}

--- a/ch360/docslots_test.go
+++ b/ch360/docslots_test.go
@@ -32,8 +32,10 @@ func Test_GetFreeDocSlots(t *testing.T) {
 			expectedErr:   ch360.ErrDocSlotsFull,
 			ctx:           context.Background(),
 		}, {
-			totalSlots:    2,
-			presentDocs:   aListOfDocuments("1", "2", "3"),
+			totalSlots:  2,
+			presentDocs: aListOfDocuments("1", "2", "3"),
+			// it's expected that the slot count could be <0,
+			// since the total slots is currently hardcoded to ch360.TotalDocumentSlots (30).
 			expectedSlots: -1,
 			expectedErr:   ch360.ErrDocSlotsFull,
 			ctx:           context.Background(),

--- a/ch360/documents.go
+++ b/ch360/documents.go
@@ -10,7 +10,7 @@ import (
 	"io"
 )
 
-var TotalDocumentSlots = 10
+var TotalDocumentSlots = 30
 
 //go:generate mockery -name "DocumentCreator|DocumentDeleter|DocumentClassifier|DocumentGetter|DocumentExtractor"
 type DocumentCreator interface {

--- a/ch360/documents.go
+++ b/ch360/documents.go
@@ -10,8 +10,6 @@ import (
 	"io"
 )
 
-var TotalDocumentSlots = 30
-
 //go:generate mockery -name "DocumentCreator|DocumentDeleter|DocumentClassifier|DocumentGetter|DocumentExtractor"
 type DocumentCreator interface {
 	Create(ctx context.Context, fileContents io.Reader) (Document, error)

--- a/cmd/surf/commands/classify.go
+++ b/cmd/surf/commands/classify.go
@@ -7,6 +7,7 @@ import (
 	"github.com/CloudHub360/ch360.go/config"
 	"github.com/CloudHub360/ch360.go/output/progress"
 	"github.com/CloudHub360/ch360.go/output/resultsWriters"
+	"github.com/pkg/errors"
 	"gopkg.in/alecthomas/kingpin.v2"
 	"os"
 )
@@ -61,7 +62,8 @@ func ConfigureClassifyCommand(ctx context.Context,
 
 // ExecuteClassify is the main entry point for the 'classify' command.
 func (cmd *ClassifyCmd) Execute(ctx context.Context) error {
-	return cmd.ClassificationService.ClassifyAll(ctx, cmd.FilePaths, cmd.ClassifierName)
+	err := cmd.ClassificationService.ClassifyAll(ctx, cmd.FilePaths, cmd.ClassifierName)
+	return errors.Wrap(err, "Classification failed")
 }
 
 func (cmd *ClassifyCmd) initWithArgs(args *classifyArgs, flags *config.GlobalFlags) error {

--- a/cmd/surf/commands/extract.go
+++ b/cmd/surf/commands/extract.go
@@ -7,6 +7,7 @@ import (
 	"github.com/CloudHub360/ch360.go/config"
 	"github.com/CloudHub360/ch360.go/output/progress"
 	"github.com/CloudHub360/ch360.go/output/resultsWriters"
+	"github.com/pkg/errors"
 	"gopkg.in/alecthomas/kingpin.v2"
 	"os"
 )
@@ -95,5 +96,7 @@ func (cmd *ExtractCmd) initWithArgs(args *extractArgs, flags *config.GlobalFlags
 
 // ExecuteExtract is the main entry point for the 'extract' command.
 func (cmd *ExtractCmd) Execute(ctx context.Context) error {
-	return cmd.ExtractionService.ExtractAll(ctx, cmd.FilePaths, cmd.ExtractorName)
+	err := cmd.ExtractionService.ExtractAll(ctx, cmd.FilePaths, cmd.ExtractorName)
+
+	return errors.Wrap(err, "Extraction failed")
 }

--- a/cmd/surf/commands/read.go
+++ b/cmd/surf/commands/read.go
@@ -102,8 +102,8 @@ func ConfigureReadCommand(ctx context.Context,
 
 // Execute is the main entry point for the 'read' command.
 func (cmd *ReadCmd) Execute(ctx context.Context) error {
-
-	return cmd.ReaderService.ReadAll(ctx, cmd.FilePaths, cmd.ReadMode)
+	err := cmd.ReaderService.ReadAll(ctx, cmd.FilePaths, cmd.ReadMode)
+	return errors.Wrap(err, "Read failed")
 }
 
 var readModes = map[string]ch360.ReadMode{

--- a/cmd/surf/commands/tests/classify_test.go
+++ b/cmd/surf/commands/tests/classify_test.go
@@ -2,10 +2,10 @@ package tests
 
 import (
 	"context"
-	"errors"
 	"github.com/CloudHub360/ch360.go/cmd/surf/commands"
 	"github.com/CloudHub360/ch360.go/cmd/surf/commands/mocks"
 	"github.com/CloudHub360/ch360.go/test/generators"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -56,6 +56,5 @@ func (suite *classifyCommandSuite) Test_ClassificationService_ClassifyAll_Called
 
 func (suite *classifyCommandSuite) Test_Error_Returned_From_ClassificationService() {
 	actualErr := suite.sut.Execute(suite.ctx)
-
-	assert.EqualError(suite.T(), actualErr, suite.expectedErr.Error())
+	assert.EqualError(suite.T(), errors.Cause(actualErr), suite.expectedErr.Error())
 }

--- a/cmd/surf/commands/tests/extract_test.go
+++ b/cmd/surf/commands/tests/extract_test.go
@@ -2,10 +2,10 @@ package tests
 
 import (
 	"context"
-	"errors"
 	"github.com/CloudHub360/ch360.go/cmd/surf/commands"
 	"github.com/CloudHub360/ch360.go/cmd/surf/commands/mocks"
 	"github.com/CloudHub360/ch360.go/test/generators"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -57,5 +57,5 @@ func (suite *extractCommandSuite) Test_ExtractionService_ExtractAll_Called_With_
 func (suite *extractCommandSuite) Test_Error_Returned_From_ExtractionService() {
 	actualErr := suite.sut.Execute(suite.ctx)
 
-	assert.EqualError(suite.T(), actualErr, suite.expectedErr.Error())
+	assert.EqualError(suite.T(), errors.Cause(actualErr), suite.expectedErr.Error())
 }

--- a/cmd/surf/commands/tests/read_test.go
+++ b/cmd/surf/commands/tests/read_test.go
@@ -2,11 +2,11 @@ package tests
 
 import (
 	"context"
-	"errors"
 	"github.com/CloudHub360/ch360.go/ch360"
 	"github.com/CloudHub360/ch360.go/cmd/surf/commands"
 	"github.com/CloudHub360/ch360.go/cmd/surf/commands/mocks"
 	"github.com/CloudHub360/ch360.go/test/generators"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -60,5 +60,5 @@ func (suite *readCommandSuite) Test_ReaderService_ReadAll_Called_With_Correct_Pa
 func (suite *readCommandSuite) Test_Error_Returned_From_ReaderService() {
 	actualErr := suite.sut.Execute(suite.ctx)
 
-	assert.EqualError(suite.T(), actualErr, suite.expectedErr.Error())
+	assert.EqualError(suite.T(), errors.Cause(actualErr), suite.expectedErr.Error())
 }

--- a/cmd/surf/services/parallelclassification.go
+++ b/cmd/surf/services/parallelclassification.go
@@ -40,14 +40,12 @@ func NewParallelClassificationService(fileClassifier FileClassifier,
 func (p *ParallelClassificationService) ClassifyAll(ctx context.Context, files []string,
 	classifierName string) error {
 
-	// Get the current number of documents, so we know how many slots are available
-	docs, err := p.documentGetter.GetAll(ctx)
+	// Limit the number of workers to the number of available doc slots
+	parallelWorkers, err := ch360.GetFreeDocSlots(ctx, p.documentGetter, ch360.TotalDocumentSlots)
+
 	if err != nil {
 		return err
 	}
-
-	// Limit the number of workers to the number of available doc slots
-	parallelWorkers := ch360.TotalDocumentSlots - len(docs)
 
 	// called in parallel, once per file
 	processorFunc := func(ctx context.Context, filename string) pool.ProcessorFunc {

--- a/cmd/surf/services/parallelextraction.go
+++ b/cmd/surf/services/parallelextraction.go
@@ -40,14 +40,12 @@ func NewParallelExtractionService(fileExtractor FileExtractor,
 func (p *ParallelExtractionService) ExtractAll(ctx context.Context, files []string,
 	extractorName string) error {
 
-	// Get the current number of documents, so we know how many slots are available
-	docs, err := p.documentGetter.GetAll(ctx)
+	// Limit the number of workers to the number of available doc slots
+	parallelWorkers, err := ch360.GetFreeDocSlots(ctx, p.documentGetter, ch360.TotalDocumentSlots)
+
 	if err != nil {
 		return err
 	}
-
-	// Limit the number of workers to the number of available doc slots
-	parallelWorkers := ch360.TotalDocumentSlots - len(docs)
 
 	// called in parallel, once per file
 	processorFunc := func(ctx context.Context, filename string) pool.ProcessorFunc {

--- a/cmd/surf/services/parallelreader.go
+++ b/cmd/surf/services/parallelreader.go
@@ -46,14 +46,12 @@ func NewParallelReaderService(fileReader FileReader,
 func (p *ParallelReaderService) ReadAll(ctx context.Context, files []string,
 	readMode ch360.ReadMode) error {
 
-	// Get the current number of documents, so we know how many slots are available
-	docs, err := p.documentGetter.GetAll(ctx)
+	// Limit the number of workers to the number of available doc slots
+	parallelWorkers, err := ch360.GetFreeDocSlots(ctx, p.documentGetter, ch360.TotalDocumentSlots)
+
 	if err != nil {
 		return err
 	}
-
-	// Limit the number of workers to the number of available doc slots
-	parallelWorkers := ch360.TotalDocumentSlots - len(docs)
 
 	// called in parallel, once per file
 	processorFunc := func(ctx context.Context, filename string) pool.ProcessorFunc {


### PR DESCRIPTION
This PR updates surf to fail with a sensible error message if all the document slots are used up when performing the read, classify or extract commands. The behaviour hasn't really changed, only the fact that an error message is now printed in this situation.

Attempting to read / classify / extract when all doc slots are full will now output a message like:

```
Read failed: all document slots are full
```

Closes #125 