### PR TITLE
Fix nits post-review

### DIFF
--- a/cmd/surf/commands/classify.go
+++ b/cmd/surf/commands/classify.go
@@ -65,7 +65,7 @@ func ConfigureClassifyCommand(ctx context.Context,
 // ExecuteClassify is the main entry point for the 'classify' command.
 func (cmd *ClassifyCmd) Execute(ctx context.Context) error {
 	err := cmd.ClassificationService.ClassifyAll(ctx, cmd.FilePaths, cmd.ClassifierName)
-	return errors.Wrap(err, "Classification failed")
+	return errors.Wrap(err, "classification failed")
 }
 
 func (cmd *ClassifyCmd) initWithArgs(args *classifyArgs, flags *config.GlobalFlags) error {

--- a/cmd/surf/commands/classify.go
+++ b/cmd/surf/commands/classify.go
@@ -58,6 +58,8 @@ func ConfigureClassifyCommand(ctx context.Context,
 	classifyCli.Arg("files", "The files to read.").
 		Required().
 		StringsVar(&classifyArgs.filePatterns)
+
+	addFileHandlingFlagsTo(globalFlags, classifyCli)
 }
 
 // ExecuteClassify is the main entry point for the 'classify' command.

--- a/cmd/surf/commands/commonflags.go
+++ b/cmd/surf/commands/commonflags.go
@@ -1,0 +1,31 @@
+package commands
+
+import (
+	"github.com/CloudHub360/ch360.go/config"
+	"github.com/pkg/errors"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+func addFileHandlingFlagsTo(globalFlags *config.GlobalFlags, cmdClause *kingpin.CmdClause) {
+
+	cmdClause.Flag("multiple-files",
+		"Write results output to multiple files with the same basename as the input").
+		Short('m').
+		BoolVar(&globalFlags.MultiFileOut)
+	cmdClause.Flag("output-file", "Write all results to the specified file").
+		Short('o').
+		PlaceHolder("file").
+		StringVar(&globalFlags.OutputFile)
+	cmdClause.Flag("progress", "Show a progress bar (only for use with -o or -m).").
+		Short('p').
+		BoolVar(&globalFlags.ShowProgress)
+
+	cmdClause.Validate(func(clause *kingpin.CmdClause) error {
+		// Only show the progress bar if stdout is redirected, or -o or -m are used
+		if globalFlags.ShowProgress && !globalFlags.CanShowProgressBar() {
+			return errors.New("The --progress / -p option can only be used when " +
+				"redirecting stdout, or in combination with -o or -m.")
+		}
+		return nil
+	})
+}

--- a/cmd/surf/commands/createclassifier.go
+++ b/cmd/surf/commands/createclassifier.go
@@ -88,7 +88,7 @@ func (cmd *CreateClassifierCmd) initFromArgs(args *createClassifierArgs, flags *
 	if err != nil {
 		// err is guaranteed to be os.PathError
 		pathErr := err.(*os.PathError)
-		return errors.Errorf("Error when opening samples archive '%s': %v",
+		return errors.Errorf("failed to open samples archive '%s': %v",
 			args.samplesArchiveFilename, pathErr.Err.Error())
 	}
 

--- a/cmd/surf/commands/createdocument.go
+++ b/cmd/surf/commands/createdocument.go
@@ -72,14 +72,14 @@ func (cmd *CreateDocumentCmd) createFromFile(ctx context.Context,
 	documentFile, err := os.Open(documentPath)
 	if err != nil {
 		pathErr := err.(*os.PathError)
-		return nil, errors.Errorf("Unable to create document from file '%s': %s", documentPath,
+		return nil, errors.Errorf("unable to create document from file '%s': %s", documentPath,
 			pathErr.Err.Error())
 	}
 	defer documentFile.Close()
 
 	doc, err := cmd.Creator.Create(ctx, documentFile)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Unable to create document from file '%s'",
+		return nil, errors.Wrapf(err, "unable to create document from file '%s'",
 			documentPath)
 	}
 	return &doc, nil

--- a/cmd/surf/commands/createdocument.go
+++ b/cmd/surf/commands/createdocument.go
@@ -44,7 +44,7 @@ func ConfigureCreateDocumentCmd(ctx context.Context, createCmd *kingpin.CmdClaus
 		})
 
 	createDocumentCli.
-		Arg("documents", "The file(s) to create documents from.").
+		Arg("files", "The file(s) to create documents from.").
 		Required().
 		StringsVar(&args.documentPaths)
 }

--- a/cmd/surf/commands/createextractor.go
+++ b/cmd/surf/commands/createextractor.go
@@ -115,13 +115,15 @@ func (cmd *CreateExtractorCmd) initFromTemplateArgs(args *createExtractorArgs, f
 	if err != nil {
 		// err is guaranteed to be os.PathError
 		pathErr := err.(*os.PathError)
-		return errors.Errorf("Error when opening template file '%s': %v", args.templateFilename, pathErr.Err.Error())
+		return errors.Errorf("failed to open template file '%s': %v", args.templateFilename,
+			pathErr.Err.Error())
 	}
 
 	cmd.Template, err = ch360.NewModulesTemplateFromJson(templateFile)
 
 	if err != nil {
-		return errors.WithMessagef(err, "Error when reading json template '%s'", args.templateFilename)
+		return errors.WithMessagef(err, "failed to read json template '%s'",
+			args.templateFilename)
 	}
 
 	return cmd.initFromArgs(args, flags)
@@ -153,7 +155,7 @@ func buildDetailedErrorMessage(errorResponse net.DetailedErrorResponse) error {
 	err := mapstructure.Decode(errorResponse.Errors, &detailedErrs)
 
 	if err != nil {
-		return errors.WithMessage(&errorResponse, "Could not deserialise response from server")
+		return errors.WithMessage(&errorResponse, "could not deserialise response from server")
 	}
 
 	sb := strings.Builder{}

--- a/cmd/surf/commands/createextractortemplate.go
+++ b/cmd/surf/commands/createextractortemplate.go
@@ -58,7 +58,7 @@ func (cmd CreateExtractorTemplateCmd) Execute(ctx context.Context) error {
 	)
 
 	if len(cmd.ModuleIds) == 0 {
-		return errors.New("At least one module ID must be specified")
+		return errors.New("at least one module ID must be specified")
 	}
 
 	allModules, err := cmd.Client.GetAll(ctx)
@@ -76,7 +76,7 @@ func (cmd CreateExtractorTemplateCmd) Execute(ctx context.Context) error {
 	jsonData, err = json.MarshalIndent(template, "", "  ")
 
 	if err != nil {
-		return errors.WithMessage(err, "Unable to create template")
+		return errors.WithMessage(err, "unable to create template")
 	}
 
 	_, err = cmd.Output.Write(jsonData)
@@ -100,7 +100,8 @@ func (cmd CreateExtractorTemplateCmd) getSpecifiedModules(existingModules ch360.
 	}
 
 	if len(missingModules) > 0 {
-		return nil, errors.Errorf("The following modules could not be found: %s", strings.Join(missingModules, ", "))
+		return nil, errors.Errorf("the following modules could not be found: %s",
+			strings.Join(missingModules, ", "))
 	}
 
 	return presentModules, nil

--- a/cmd/surf/commands/deleteclassifier.go
+++ b/cmd/surf/commands/deleteclassifier.go
@@ -65,7 +65,7 @@ func (cmd *DeleteClassifierCmd) Execute(ctx context.Context) error {
 	}
 
 	if !classifiers.Contains(cmd.ClassifierName) {
-		return errors.New("There is no classifier named '" + cmd.ClassifierName + "'")
+		return errors.New("there is no classifier named '" + cmd.ClassifierName + "'")
 	}
 
 	return cmd.Client.Delete(ctx, cmd.ClassifierName)

--- a/cmd/surf/commands/deletedocuments.go
+++ b/cmd/surf/commands/deletedocuments.go
@@ -144,7 +144,7 @@ func (cmd *DeleteDocumentCmd) checkProvidedDocuments(allDocs []string) error {
 	}
 
 	if len(missingDocIds) > 0 {
-		return errors.Errorf("The following documents could not be found: %s",
+		return errors.Errorf("the following documents could not be found: %s",
 			strings.Join(missingDocIds, ", "))
 	}
 	return nil

--- a/cmd/surf/commands/deleteextractor.go
+++ b/cmd/surf/commands/deleteextractor.go
@@ -57,7 +57,7 @@ func (cmd *DeleteExtractorCmd) Execute(ctx context.Context) error {
 	}
 
 	if !extractors.Contains(cmd.ExtractorName) {
-		return errors.New("There is no extractor named '" + cmd.ExtractorName + "'")
+		return errors.New("there is no extractor named '" + cmd.ExtractorName + "'")
 	}
 
 	return cmd.Client.Delete(ctx, cmd.ExtractorName)

--- a/cmd/surf/commands/extract.go
+++ b/cmd/surf/commands/extract.go
@@ -100,5 +100,5 @@ func (cmd *ExtractCmd) initWithArgs(args *extractArgs, flags *config.GlobalFlags
 func (cmd *ExtractCmd) Execute(ctx context.Context) error {
 	err := cmd.ExtractionService.ExtractAll(ctx, cmd.FilePaths, cmd.ExtractorName)
 
-	return errors.Wrap(err, "Extraction failed")
+	return errors.Wrap(err, "extraction failed")
 }

--- a/cmd/surf/commands/extract.go
+++ b/cmd/surf/commands/extract.go
@@ -57,6 +57,8 @@ func ConfigureExtractCommand(ctx context.Context,
 	extractCli.Arg("files", "The files to read.").
 		Required().
 		StringsVar(&args.filePatterns)
+
+	addFileHandlingFlagsTo(globalFlags, extractCli)
 }
 
 func (cmd *ExtractCmd) initWithArgs(args *extractArgs, flags *config.GlobalFlags) error {

--- a/cmd/surf/commands/read.go
+++ b/cmd/surf/commands/read.go
@@ -105,7 +105,7 @@ func ConfigureReadCommand(ctx context.Context,
 // Execute is the main entry point for the 'read' command.
 func (cmd *ReadCmd) Execute(ctx context.Context) error {
 	err := cmd.ReaderService.ReadAll(ctx, cmd.FilePaths, cmd.ReadMode)
-	return errors.Wrap(err, "Read failed")
+	return errors.Wrap(err, "read failed")
 }
 
 var readModes = map[string]ch360.ReadMode{

--- a/cmd/surf/commands/read.go
+++ b/cmd/surf/commands/read.go
@@ -98,6 +98,8 @@ func ConfigureReadCommand(ctx context.Context,
 	cliCmd.Arg("files", "The files to read.").
 		Required().
 		StringsVar(&readArgs.filePatterns)
+
+	addFileHandlingFlagsTo(globalFlags, cliCmd)
 }
 
 // Execute is the main entry point for the 'read' command.

--- a/cmd/surf/commands/redact.go
+++ b/cmd/surf/commands/redact.go
@@ -53,6 +53,8 @@ func ConfigureRedactWithExtractionCommand(ctx context.Context,
 	redactWithExtractorCli.Arg("files", "The files to read.").
 		Required().
 		StringsVar(&args.filePatterns)
+
+	addFileHandlingFlagsTo(globalFlags, redactCli)
 }
 
 func (cmd *RedactWithExtractorCmd) initWithArgs(args *redactWithExtractorArgs, flags *config.GlobalFlags) error {

--- a/cmd/surf/commands/redact.go
+++ b/cmd/surf/commands/redact.go
@@ -99,5 +99,5 @@ func (cmd *RedactWithExtractorCmd) initWithArgs(args *redactWithExtractorArgs, f
 func (cmd *RedactWithExtractorCmd) Execute(ctx context.Context) error {
 	err := cmd.RedactionService.RedactAllWithExtractor(ctx, cmd.FilePaths, cmd.ExtractorName)
 
-	return errors.Wrap(err, "Redaction failed")
+	return errors.Wrap(err, "redaction failed")
 }

--- a/cmd/surf/commands/redact.go
+++ b/cmd/surf/commands/redact.go
@@ -81,6 +81,11 @@ func (cmd *RedactWithExtractorCmd) initWithArgs(args *redactWithExtractorArgs, f
 		return err
 	}
 
+	if !config.IsOutputRedirected() &&
+		!flags.IsOutputSpecified() {
+		return errors.New("you must use '-o' or '-m' or redirect stdout when redacting files")
+	}
+
 	fileRedactor := ch360.NewFileRedactor(client.Documents, client.Documents, client.Documents,
 		client.Documents)
 

--- a/cmd/surf/commands/uploadclassifier.go
+++ b/cmd/surf/commands/uploadclassifier.go
@@ -68,7 +68,7 @@ func (cmd *UploadClassifierCmd) initFromArgs(args *uploadClassifierArgs, flags *
 	var err error
 	cmd.ClassifierContents, err = os.Open(args.classifierFile)
 	if err != nil {
-		return errors.New(fmt.Sprintf("The file '%s' could not be found.", args.classifierFile))
+		return errors.New(fmt.Sprintf("the file '%s' could not be found", args.classifierFile))
 	}
 
 	cmd.ClassifierName = args.name

--- a/cmd/surf/commands/uploadextractor.go
+++ b/cmd/surf/commands/uploadextractor.go
@@ -74,7 +74,7 @@ func (cmd *UploadExtractorCmd) initFromArgs(args *uploadExtractorArgs,
 	var err error
 	cmd.ExtractorContent, err = os.Open(args.extractorFile)
 	if err != nil {
-		return errors.Errorf("The file '%s' could not be found.", args.extractorFile)
+		return errors.Errorf("the file '%s' could not be found", args.extractorFile)
 	}
 
 	client, err := initApiClient(flags.ClientId, flags.ClientSecret, flags.LogHttp)

--- a/cmd/surf/surf.go
+++ b/cmd/surf/surf.go
@@ -50,20 +50,16 @@ func main() {
 
 	app.Flag("client-id", "Client ID").
 		Short('i').
+		PlaceHolder("id").
 		StringVar(&globalFlags.ClientId)
 	app.Flag("client-secret", "Client secret").
 		Short('s').
+		PlaceHolder("secret").
 		StringVar(&globalFlags.ClientSecret)
 	app.Flag("log-http", "Log HTTP requests and responses as they happen, "+
 		"to a file.").
+		PlaceHolder("file").
 		OpenFileVar(&globalFlags.LogHttp, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
-	app.Flag("multiple-files",
-		"Write results output to multiple files with the same basename as the input").
-		Short('m').
-		BoolVar(&globalFlags.MultiFileOut)
-	app.Flag("output-file", "Write all results to the specified file").
-		Short('o').
-		StringVar(&globalFlags.OutputFile)
 	app.Flag("version", "Show the application version.").
 		PreAction(func(parseContext *kingpin.ParseContext) error {
 			fmt.Println(ch360.Version)
@@ -71,19 +67,9 @@ func main() {
 			return nil
 		}).
 		Bool()
-	app.Flag("progress", "Show a progress bar."+
-		"Only available in combination with the read, extract and classify commands.").
-		Short('p').
-		BoolVar(&globalFlags.ShowProgress)
 
-	app.Validate(func(application *kingpin.Application) error {
-		// Only show the progress bar if stdout is redirected, or -o or -m are used
-		if globalFlags.ShowProgress && !globalFlags.CanShowProgressBar() {
-			return errors.New("The --progress / -p option can only be used when " +
-				"redirecting stdout, or in combination with -o or -m.")
-		}
-		return nil
-	})
+	app.UsageTemplate(kingpin.CompactUsageTemplate)
+	app.HelpFlag.Hidden()
 
 	defer ioutils.TryClose(globalFlags.LogHttp)
 

--- a/cmd/surf/surf.go
+++ b/cmd/surf/surf.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 	"os"
 	"os/signal"
+	"strings"
 )
 
 func main() {
@@ -87,8 +88,11 @@ func handleInterrupt(canceller context.CancelFunc) {
 
 func exitOnErr(err error) {
 	if err != nil && errors.Cause(err) != context.Canceled {
-
-		_, _ = fmt.Fprintln(os.Stderr, err)
+		msg := "Error: " + err.Error()
+		if !strings.HasSuffix(msg, ".") {
+			msg = msg + "."
+		}
+		_, _ = fmt.Fprintln(os.Stderr, msg)
 
 		os.Exit(1)
 	}

--- a/test/surf-classifier.Tests.ps1
+++ b/test/surf-classifier.Tests.ps1
@@ -87,7 +87,7 @@ Creating classifier '$classifierName'... [FAILED]
         $samples = (Join-Path $PSScriptRoot "non-existent.zip")
         New-Classifier $classifierName $samples | Format-MultilineOutput | Should -Be @"
 Creating classifier 'test-classifier'... [FAILED]
-Error when opening samples archive '$samples': no such file or directory
+Error: failed to open samples archive '$samples': no such file or directory.
 "@
 
         $LASTEXITCODE | Should -Be 1

--- a/test/surf-extraction.Tests.ps1
+++ b/test/surf-extraction.Tests.ps1
@@ -40,7 +40,7 @@ Uploading extractor '$extractorName'... [OK]
        $extractorDefinition = (Join-Path $PSScriptRoot "invalid.fpxlc")
        New-Extractor $extractorName $extractorDefinition | Format-MultilineOutput | Should -Be @"
 Uploading extractor 'test-extractor'... [FAILED]
-The file supplied is not a valid extractor configuration file.
+Error: The file supplied is not a valid extractor configuration file.
 "@
        $LASTEXITCODE | Should -Be 1
 
@@ -52,7 +52,7 @@ The file supplied is not a valid extractor configuration file.
         $extractorDefinition = (Join-Path $PSScriptRoot "non-existent.fpxlc")
         New-Extractor $extractorName $extractorDefinition | Format-MultilineOutput | Should -Be @"
 Uploading extractor 'test-extractor'... [FAILED]
-The file '$extractorDefinition' could not be found.
+Error: the file '$extractorDefinition' could not be found.
 "@
         $LASTEXITCODE | Should -Be 1
 
@@ -93,7 +93,7 @@ Creating extractor '$extractorName'... [OK]
         $extractorTemplate = "missing.json"
         New-ExtractorFromTemplate $extractorName $extractorTemplate | Format-MultilineOutput | Should -Be @"
 Creating extractor 'test-extractor'... [FAILED]
-Error when opening template file 'missing.json': no such file or directory
+Error: failed to open template file 'missing.json': no such file or directory.
 "@
         $LASTEXITCODE | Should -Be 1
     }
@@ -102,7 +102,7 @@ Error when opening template file 'missing.json': no such file or directory
         $extractorTemplate = (Join-Path $PSScriptRoot "invalid.json")
         New-ExtractorFromTemplate $extractorName $extractorTemplate | Format-MultilineOutput | Should -Be @"
 Creating extractor 'test-extractor'... [FAILED]
-Error when reading json template '$extractorTemplate': invalid character 'b' looking for beginning of value
+Error: failed to read json template '$extractorTemplate': invalid character 'b' looking for beginning of value.
 "@
         $LASTEXITCODE | Should -Be 1
     }


### PR DESCRIPTION
This PR switches to a more compact help text format, and ensures the file handling / output writing flags are only present on the `read`, `redact`, `classify` and `extract` commands.

It also fixes a bug where redacted PDFs could be written to stdout when it wasn't redirected.